### PR TITLE
The makeTxDb*() functions have moved from GenomicFeatures to txdbmaker

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: doubletrouble
 Title: Identification and classification of duplicated genes
-Version: 1.3.5
-Date: 2022-05-29
+Version: 1.3.6
+Date: 2024-03-19
 Authors@R: 
     c(
     person(given = "Fabrício",
@@ -47,7 +47,7 @@ biocViews:
 Encoding: UTF-8
 LazyData: false
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.1
 Imports:
     syntenet,
     GenomicRanges,
@@ -64,6 +64,7 @@ Imports:
 Depends: 
     R (>= 4.2.0)
 Suggests: 
+    txdbmaker,
     testthat (>= 3.0.0),
     knitr,
     feature,

--- a/R/duplicate_classification.R
+++ b/R/duplicate_classification.R
@@ -76,7 +76,8 @@
 #' annotation <- syntenet::process_input(yeast_seq, yeast_annot)$annotation
 #' 
 #' # Get list of intron counts
-#' txdb_list <- lapply(yeast_annot, GenomicFeatures::makeTxDbFromGRanges)
+#' library(txdbmaker)
+#' txdb_list <- lapply(yeast_annot, txdbmaker::makeTxDbFromGRanges)
 #' intron_counts <- lapply(txdb_list, get_intron_counts)
 #' 
 #' # Classify duplicates - full scheme

--- a/R/utils.R
+++ b/R/utils.R
@@ -117,8 +117,8 @@ collinearity2blocks <- function(collinearity_paths = NULL) {
 
 #' Get a data frame of intron counts per gene
 #' 
-#' @param txdb A `txdb` object with transcript annotations. See details below 
-#' for examples on how to create `txdb` objects from different kinds of input.
+#' @param txdb A `TxDb` object with transcript annotations. See details below 
+#' for examples on how to create `TxDb` objects from different kinds of input.
 #' 
 #' 
 #' @return A data frame with intron counts per gene, with variables:
@@ -129,8 +129,8 @@ collinearity2blocks <- function(collinearity_paths = NULL) {
 #' 
 #' @details
 #' The family of functions \code{makeTxDbFrom*} from 
-#' the \strong{GenomicFeatures} package can be used to create `txdb` objects
-#' from a variety of input data types. You can create `txdb` objects
+#' the \strong{txdbmaker} package can be used to create `TxDb` objects
+#' from a variety of input data types. You can create `TxDb` objects
 #' from e.g., `GRanges` objects (\code{makeTxDbFromGRanges()}),
 #' GFF files (\code{makeTxDbFromGFF()}), 
 #' an Ensembl database (\code{makeTxDbFromEnsembl}), and
@@ -144,8 +144,9 @@ collinearity2blocks <- function(collinearity_paths = NULL) {
 #' @examples
 #' data(yeast_annot)
 #' 
-#' # Create txdb object from GRanges
-#' txdb <- GenomicFeatures::makeTxDbFromGRanges(yeast_annot[[1]])
+#' # Create TxDb object from GRanges
+#' library(txdbmaker)
+#' txdb <- txdbmaker::makeTxDbFromGRanges(yeast_annot[[1]])
 #'
 #' # Get intron counts
 #' intron_counts <- get_intron_counts(txdb)

--- a/R/utils_duplicate_classification.R
+++ b/R/utils_duplicate_classification.R
@@ -324,8 +324,9 @@ get_transposed <- function(
 #' # Classify pairs
 #' trd <- get_transposed(pairs, diamond_inter, annotation)
 #' 
-#' # Create txdb object from GRanges
-#' txdb <- GenomicFeatures::makeTxDbFromGRanges(yeast_annot[[1]])
+#' # Create TxDb object from GRanges
+#' library(txdbmaker)
+#' txdb <- txdbmaker::makeTxDbFromGRanges(yeast_annot[[1]])
 #'
 #' # Get intron counts
 #' intron_counts <- get_intron_counts(txdb)

--- a/man/classify_gene_pairs.Rd
+++ b/man/classify_gene_pairs.Rd
@@ -103,7 +103,8 @@ data(yeast_seq)
 annotation <- syntenet::process_input(yeast_seq, yeast_annot)$annotation
 
 # Get list of intron counts
-txdb_list <- lapply(yeast_annot, GenomicFeatures::makeTxDbFromGRanges)
+library(txdbmaker)
+txdb_list <- lapply(yeast_annot, txdbmaker::makeTxDbFromGRanges)
 intron_counts <- lapply(txdb_list, get_intron_counts)
 
 # Classify duplicates - full scheme

--- a/man/get_intron_counts.Rd
+++ b/man/get_intron_counts.Rd
@@ -7,8 +7,8 @@
 get_intron_counts(txdb)
 }
 \arguments{
-\item{txdb}{A \code{txdb} object with transcript annotations. See details below
-for examples on how to create \code{txdb} objects from different kinds of input.}
+\item{txdb}{A \code{TxDb} object with transcript annotations. See details below
+for examples on how to create \code{TxDb} objects from different kinds of input.}
 }
 \value{
 A data frame with intron counts per gene, with variables:
@@ -22,8 +22,8 @@ Get a data frame of intron counts per gene
 }
 \details{
 The family of functions \code{makeTxDbFrom*} from
-the \strong{GenomicFeatures} package can be used to create \code{txdb} objects
-from a variety of input data types. You can create \code{txdb} objects
+the \strong{txdbmaker} package can be used to create \code{TxDb} objects
+from a variety of input data types. You can create \code{TxDb} objects
 from e.g., \code{GRanges} objects (\code{makeTxDbFromGRanges()}),
 GFF files (\code{makeTxDbFromGFF()}),
 an Ensembl database (\code{makeTxDbFromEnsembl}), and
@@ -32,8 +32,9 @@ a Biomart database (\code{makeTxDbFromBiomart}).
 \examples{
 data(yeast_annot)
 
-# Create txdb object from GRanges
-txdb <- GenomicFeatures::makeTxDbFromGRanges(yeast_annot[[1]])
+# Create TxDb object from GRanges
+library(txdbmaker)
+txdb <- txdbmaker::makeTxDbFromGRanges(yeast_annot[[1]])
 
 # Get intron counts
 intron_counts <- get_intron_counts(txdb)

--- a/man/get_transposed_classes.Rd
+++ b/man/get_transposed_classes.Rd
@@ -53,8 +53,9 @@ pairs$dup2 <- paste0("Sce_", pairs$dup2)
 # Classify pairs
 trd <- get_transposed(pairs, diamond_inter, annotation)
 
-# Create txdb object from GRanges
-txdb <- GenomicFeatures::makeTxDbFromGRanges(yeast_annot[[1]])
+# Create TxDb object from GRanges
+library(txdbmaker)
+txdb <- txdbmaker::makeTxDbFromGRanges(yeast_annot[[1]])
 
 # Get intron counts
 intron_counts <- get_intron_counts(txdb)

--- a/tests/testthat/test-duplicate_classification.R
+++ b/tests/testthat/test-duplicate_classification.R
@@ -1,3 +1,4 @@
+library(txdbmaker)  # for makeTxDbFromGRanges()
 
 #----Load data------------------------------------------------------------------
 data(diamond_intra)
@@ -25,7 +26,7 @@ ssd <- all[all$type != "SD", 1:2]
 duplicates <- diamond_intra[[1]][, 1:2]
 
 
-txdb <- GenomicFeatures::makeTxDbFromGRanges(yeast_annot[[1]])
+txdb <- txdbmaker::makeTxDbFromGRanges(yeast_annot[[1]])
 intron_counts <- get_intron_counts(txdb)
 
 ic_list <- list(Scerevisiae = intron_counts)

--- a/vignettes/doubletrouble_vignette.Rmd
+++ b/vignettes/doubletrouble_vignette.Rmd
@@ -347,21 +347,22 @@ of data frames with the number of introns per gene for each species. This
 can be done with the function `get_intron_counts()`, which takes a `TxDb` 
 object as input. `TxDb` objects store transcript annotations, and they 
 can be created with a family of functions
-named `makeTxDbFrom*` from the `r BiocStyle::Biocpkg("GenomicFeatures")`
+named `makeTxDbFrom*` from the `r BiocStyle::Biocpkg("txdbmaker")`
 package (see `?get_intron_counts()` for a summary of all functions).
 
 
 Here, we will create a list of `TxDb` objects from a list of `GRanges` objects
-using the function `MakeTxDbFromGRanges` 
-from `r BiocStyle::Biocpkg("GenomicFeatures")`. Importantly, to create
+using the function `makeTxDbFromGRanges` 
+from `r BiocStyle::Biocpkg("txdbmaker")`. Importantly, to create
 a `TxDb` from a `GRanges`, the `GRanges` object must contain genomic coordinates
 for all features, including transcripts, exons, etc. Because of that, we
 will use annotation from the example data set `yeast_annot`,
 which was not processed with `syntenet::process_input()`.
 
 ```{r}
+library(txdbmaker)
 # Create a list of `TxDb` objects from a list of `GRanges` objects
-txdb_list <- lapply(yeast_annot, GenomicFeatures::makeTxDbFromGRanges)
+txdb_list <- lapply(yeast_annot, txdbmaker::makeTxDbFromGRanges)
 txdb_list
 ```
 


### PR DESCRIPTION
This PR fixes the ERROR we see on the [Bioconductor daily builds](https://bioconductor.org/checkResults/3.19/bioc-LATEST/doubletrouble/) on the Linux builders.

Best,
H.