### PR TITLE
Fix interval creation logic in ka_ks_analyses.R

### DIFF
--- a/R/ka_ks_analyses.R
+++ b/R/ka_ks_analyses.R
@@ -263,7 +263,7 @@ split_pairs_by_peak <- function(ks_df, peaks, nsd = 2, binwidth = 0.05) {
     
     # Create list of intervals
     int_list <- lapply(seq_len(length(cutpoints)-1), function(x) {
-        return(c(cutpoints[x], cutpoints[x] + 1))
+        return(c(cutpoints[x], cutpoints[x+1]))
     })
     
     # Create list of data frames for each interval


### PR DESCRIPTION
This patch fixes a logic bug in the creation of peak interval bins from Ks cutpoints in split_pairs_by_peak (or related code). Previously, intervals were constructed as [cutpoints[x], cutpoints[x] + 1], which would only create fixed-width ranges (of size 1), lead to missing gene pairs located between more distant cutpoints and the redundant gene pairs between close peaks. The corrected code changes this to [cutpoints[x], cutpoints[x+1]], ensuring bins accurately span the entire range between neighboring GMM peak intersections and all Ks values are appropriately categorized.